### PR TITLE
chore: stable source date epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+# inital commit time
+# git rev-list --max-parents=0 HEAD
+# git log d31b8c41c87600f2d881508bb40aad232659f9bb --pretty=%ct
+SOURCE_DATE_EPOCH ?= "1602102660"
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.1.0-alpha.0-38-g91bb939
+  PKGS_VERSION: v1.1.0-alpha.0-46-g1f48da7
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Use the timestamp from repo initial commit as `SOURCE_DATE_EPOCH`

Bump to pkgs built with stable [`SOURCE_DATE_EPOCH`](https://github.com/siderolabs/pkgs/pull/489)

Signed-off-by: Noel Georgi <git@frezbo.dev>