### PR TITLE
chore: bump golang to 1.18.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.1.0
+  PKGS_VERSION: v1.2.0-alpha.0-1-g4d47830
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Bump Golang to [1.18.3](https://github.com/siderolabs/pkgs/pull/498)

Signed-off-by: Noel Georgi <git@frezbo.dev>