### PR TITLE
chore: bump golang to 1.17.11

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.0.0-15-g1dd581a
+  PKGS_VERSION: v1.0.0-22-gb01e120
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Bump Golang to [1.17.11](https://github.com/siderolabs/pkgs/pull/500)

Signed-off-by: Noel Georgi <git@frezbo.dev>