### PR TITLE
chore: update to the final tagged pkgs

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.2.0-alpha.0-25-g6feece4
+  PKGS_VERSION: v1.2.0
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Use 1.2.0 version targeting Talos 1.2.0.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>