### PR TITLE
chore: bump go to 1.19.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.2.0
+  PKGS_VERSION: v1.2.0-9-gb264dc2
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Bump go to 1.19.1

Signed-off-by: Noel Georgi <git@frezbo.dev>