### PR TITLE
chore: bump go to 1.19.2

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.2.0
+  PKGS_VERSION: v1.3.0-alpha.0-27-gb16dfe9
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Bump Go to [1.19.2](https://github.com/siderolabs/pkgs/pull/599)

Signed-off-by: Noel Georgi <git@frezbo.dev>