### PR TITLE
chore: update packages

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.3.0-2-g551787c
+  PKGS_VERSION: v1.3.0-11-gffdc9f1
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/awslabs/tc-redirect-tap.git
   tc_redirect_tap_ref: b589b55eaf3c40b5724009929ef08e897711389f


### PR DESCRIPTION
This brings back Flannel CNI to 1.1.2.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>