### PR TITLE
feat: update dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-06-05T12:39:45Z by kres f292767.
+# Generated on 2024-07-03T14:11:08Z by kres 8c8b007.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.13.2
+        image: moby/buildkit:v0.14.1
         options: --privileged
         ports:
           - 1234:1234
@@ -81,6 +81,7 @@ jobs:
           driver: remote
           endpoint: tcp://127.0.0.1:1234
       - name: Build
+        if: github.event_name == 'pull_request'
         run: |
           make
       - name: Login to registry
@@ -128,7 +129,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.13.2
+        image: moby/buildkit:v0.14.1
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-06-05T12:39:45Z by kres f292767.
+# Generated on 2024-07-03T14:11:08Z by kres 8c8b007.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.13.2
+        image: moby/buildkit:v0.14.1
         options: --privileged
         ports:
           - 1234:1234

--- a/Pkgfile
+++ b/Pkgfile
@@ -4,12 +4,12 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.8.0-alpha.0-23-gc309452
+  PKGS_VERSION: v1.8.0-alpha.0-34-gce49757
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/awslabs/tc-redirect-tap.git
-  tc_redirect_tap_ref: f4bce16532c34740691b2e10c3945020a3c4fd5e
-  tc_redirect_tap_sha256: bf55b2b25d9e0fe280f3698deef8eab0a3d5e50a133d25b5f4307ba73e21f7d4
-  tc_redirect_tap_sha512: 27444ce69f7e1618ed0a9ba16cdd397f3b40dcc351ee515da095d565f79ba0e6b79eb235dca042a2bbfecc85f5cabc53d4d4af24bf957c5a010d31734043c6ca
+  tc_redirect_tap_ref: 97e0d3caefe891c05ad9b8faed06771b1d29407c
+  tc_redirect_tap_sha256: d706ff97e4447bbd926e23e109bb23fa89236f8132568cc53b7c99cb3a352331
+  tc_redirect_tap_sha512: b1fcf19ac28da7c9c2a52f2a1791a20d8610f47b67ea369016e15ba117b6ed4a12f8528c24279ab21b8ae1ecc74b222f07ae003abb8dfca024f8d80f180995e0
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Bring new Go 1.22.5 via pkgs, update `tc-redirct-tap`.

Also brings in new