### PR TITLE
chore: bump deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-07-03T14:11:08Z by kres 8c8b007.
+# Generated on 2024-08-07T15:33:12Z by kres dbf015a.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.14.1
+        image: moby/buildkit:v0.15.1
         options: --privileged
         ports:
           - 1234:1234
@@ -129,7 +129,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.14.1
+        image: moby/buildkit:v0.15.1
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-07-03T14:11:08Z by kres 8c8b007.
+# Generated on 2024-08-07T15:33:12Z by kres dbf015a.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.14.1
+        image: moby/buildkit:v0.15.1
         options: --privileged
         ports:
           - 1234:1234

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-06-05T12:39:45Z by kres f292767.
+# Generated on 2024-08-07T15:33:12Z by kres dbf015a.
 
 # common variables
 
@@ -25,7 +25,7 @@ SOURCE_DATE_EPOCH := $(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)
 
 # sync bldr image with pkgfile
 
-BLDR_RELEASE := v0.3.1
+BLDR_RELEASE := v0.3.2
 BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)
 BLDR := docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,10 +1,10 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.3.1
+# syntax = ghcr.io/siderolabs/bldr:v0.3.2
 
 format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.8.0-alpha.0-34-gce49757
+  PKGS_VERSION: v1.8.0-alpha.0-45-gaf6b4e6
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/awslabs/tc-redirect-tap.git
   tc_redirect_tap_ref: 97e0d3caefe891c05ad9b8faed06771b1d29407c


### PR DESCRIPTION
- run rekres (bump buildkit to v0.15.1)
- bump bldr to v0.3.2
- bump pkgs to v1.8.0-alpha.0-45-gaf6b4e6