### PR TITLE
chore: use Go 1.22.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,12 +4,12 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.8.0-alpha.0-45-gaf6b4e6
+  PKGS_VERSION: v1.8.0-alpha.0-46-g124d35b
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/awslabs/tc-redirect-tap.git
-  tc_redirect_tap_ref: 97e0d3caefe891c05ad9b8faed06771b1d29407c
-  tc_redirect_tap_sha256: d706ff97e4447bbd926e23e109bb23fa89236f8132568cc53b7c99cb3a352331
-  tc_redirect_tap_sha512: b1fcf19ac28da7c9c2a52f2a1791a20d8610f47b67ea369016e15ba117b6ed4a12f8528c24279ab21b8ae1ecc74b222f07ae003abb8dfca024f8d80f180995e0
+  tc_redirect_tap_ref: 2db41f504194e5fa2b1451647c2154c0a840b02c
+  tc_redirect_tap_sha256: 438d6d95f5175bfe06b4daf239c86fea39a96042873648cdec25f2704fce66da
+  tc_redirect_tap_sha512: a1d290d540d5047ee3dfa4f3a9b538a213603cad6dc8be8361baa35f94177682312dfd0379b8365b48b4e39bec4bc4ffc001eacba0ce0c6e252d7341b739c6ce
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extras


### PR DESCRIPTION
Use Go1.22.6 via pkgs, also bump deps.