### PR TITLE
feat: update dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T18:40:00Z by kres fcff05e.
+# Generated on 2025-03-05T12:43:59Z by kres 30e7a85.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.18.2
+        image: moby/buildkit:v0.20.0
         options: --privileged
         ports:
           - 1234:1234
@@ -129,7 +129,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.18.2
+        image: moby/buildkit:v0.20.0
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-18T18:40:00Z by kres fcff05e.
+# Generated on 2025-03-05T12:43:59Z by kres 30e7a85.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.18.2
+        image: moby/buildkit:v0.20.0
         options: --privileged
         ports:
           - 1234:1234

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-06T12:31:14Z by kres 987bf4d.
+# Generated on 2025-03-05T12:43:59Z by kres 30e7a85.
 
 # common variables
 
@@ -25,7 +25,7 @@ SOURCE_DATE_EPOCH := $(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)
 
 # sync bldr image with pkgfile
 
-BLDR_RELEASE := v0.4.0-1-g76a2c8f
+BLDR_RELEASE := v0.4.1
 BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)
 BLDR := docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,10 +1,12 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.4.0-1-g76a2c8f
+# syntax = ghcr.io/siderolabs/bldr:v0.4.1
 
 format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.10.0-alpha.0-35-g85f8901
+  PKGS_VERSION: v1.10.0-alpha.0-52-g1d84473
+  TOOLS_PREFIX: ghcr.io/siderolabs
+  TOOLS_VERSION: v1.10.0-alpha.0-19-g87acb27
 
   # renovate: datasource=git-refs versioning=git depName=https://github.com/awslabs/tc-redirect-tap.git
   tc_redirect_tap_ref: fb2c2b5e660adb567157c9d69e1de19b0c7c4f37

--- a/base/pkg.yaml
+++ b/base/pkg.yaml
@@ -1,8 +1,7 @@
 name: base
 variant: scratch
 dependencies:
-  - image: "{{ .PKGS_PREFIX }}/base:{{ .PKGS_VERSION }}"
-  - image: "{{ .PKGS_PREFIX }}/ca-certificates:{{ .PKGS_VERSION }}"
+  - image: "{{ .TOOLS_PREFIX }}/tools:{{ .TOOLS_VERSION }}"
 finalize:
   - from: /
     to: /


### PR DESCRIPTION
Bring in Go 1.24.1, update removed base layer.

Rekres.