### PR TITLE
chore: add sbr and macvlan to cni bundle

### DIFF
--- a/talosctl-cni-bundle/pkg.yaml
+++ b/talosctl-cni-bundle/pkg.yaml
@@ -10,7 +10,7 @@ steps:
       - |
         mkdir -p /rootfs/opt/cni/bin
 
-        cp /opt/cni/bin/{bridge,firewall,static,tc-redirect-tap} /rootfs/opt/cni/bin/
+        cp /opt/cni/bin/{sbr,bridge,firewall,macvlan,static,tc-redirect-tap} /rootfs/opt/cni/bin/
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
We typically use these two for Multus